### PR TITLE
change frame_ids to be optional parameters + fix odometry child_frame_id to reflect child and not world frame

### DIFF
--- a/global_fusion/src/globalOpt.cpp
+++ b/global_fusion/src/globalOpt.cpp
@@ -13,8 +13,6 @@
 #include "Factors.h"
 
 
-
-
 GlobalOptimization::GlobalOptimization()
 {
 	initGPS = false;
@@ -64,7 +62,7 @@ void GlobalOptimization::inputOdom(double t, Eigen::Vector3d OdomP, Eigen::Quate
     pose_stamped.header.stamp.sec = sec_ts;
     pose_stamped.header.stamp.nanosec = nsec_ts;
 
-    pose_stamped.header.frame_id = "world";
+    pose_stamped.header.frame_id = world_frame_id;
     pose_stamped.pose.position.x = lastP.x();
     pose_stamped.pose.position.y = lastP.y();
     pose_stamped.pose.position.z = lastP.z();
@@ -269,7 +267,7 @@ void GlobalOptimization::updateGlobalPath()
         pose_stamped.header.stamp.sec = sec_ts;
         pose_stamped.header.stamp.nanosec = nsec_ts;
 
-        pose_stamped.header.frame_id = "world";
+        pose_stamped.header.frame_id = world_frame_id;
         pose_stamped.pose.position.x = iter->second[0];
         pose_stamped.pose.position.y = iter->second[1];
         pose_stamped.pose.position.z = iter->second[2];

--- a/global_fusion/src/globalOpt.h
+++ b/global_fusion/src/globalOpt.h
@@ -41,10 +41,7 @@ public:
 	void inputOdom(double t, Eigen::Vector3d OdomP, Eigen::Quaterniond OdomQ);
 	void getGlobalOdom(Eigen::Vector3d &odomP, Eigen::Quaterniond &odomQ);
 	nav_msgs::msg::Path global_path;
-
-	
-
-
+	std::string world_frame_id = "world";
 
 private:
 	void GPS2XYZ(double latitude, double longitude, double altitude, double* xyz);

--- a/global_fusion/src/globalOptNode.cpp
+++ b/global_fusion/src/globalOptNode.cpp
@@ -30,6 +30,8 @@ rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_global_odometry;
 rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_global_path;
 rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_car;
 nav_msgs::msg::Path *global_path;
+std::string world_frame_id;
+std::string body_frame_id;
 double last_vio_t = -1;
 std::queue<sensor_msgs::msg::NavSatFix::SharedPtr> gpsQueue;
 std::mutex m_buf;
@@ -44,7 +46,7 @@ void publish_car_model(double t, Eigen::Vector3d t_w_car, Eigen::Quaterniond q_w
     car_mesh.header.stamp.sec = sec_ts;
     car_mesh.header.stamp.nanosec = nsec_ts;
 
-    car_mesh.header.frame_id = "world";
+    car_mesh.header.frame_id = world_frame_id;
     car_mesh.type = visualization_msgs::msg::Marker::MESH_RESOURCE;
     car_mesh.action = visualization_msgs::msg::Marker::ADD;
     car_mesh.id = 0;
@@ -129,8 +131,8 @@ void vio_callback(const nav_msgs::msg::Odometry::SharedPtr pose_msg)
 
     nav_msgs::msg::Odometry odometry;
     odometry.header = pose_msg->header;
-    odometry.header.frame_id = "world";
-    odometry.child_frame_id = "world";
+    odometry.header.frame_id = world_frame_id;
+    odometry.child_frame_id = body_frame_id;
     odometry.pose.pose.position.x = global_t.x();
     odometry.pose.pose.position.y = global_t.y();
     odometry.pose.pose.position.z = global_t.z();
@@ -176,14 +178,15 @@ int main(int argc, char **argv)
     auto n = rclcpp::Node::make_shared("globalEstimator");
     auto qos_profile = rclcpp::QoS(rclcpp::KeepLast(100));
 
+    n->declare_parameter<std::string>("world_frame_id", "world");
+    n->declare_parameter<std::string>("body_frame_id", "body");
+    world_frame_id = n->get_parameter("world_frame_id").as_string();
+    body_frame_id = n->get_parameter("body_frame_id").as_string();
+    globalEstimator.world_frame_id = world_frame_id;
 
     auto sub_GPS = n->create_subscription<sensor_msgs::msg::NavSatFix>("/gps", rclcpp::QoS(rclcpp::KeepLast(100)), GPS_callback);
 
     auto sub_vio = n->create_subscription<nav_msgs::msg::Odometry>("/vins_estimator/odometry", rclcpp::QoS(rclcpp::KeepLast(100)), vio_callback);
-
-
-
-
 
     pub_global_path = n->create_publisher<nav_msgs::msg::Path>("global_path", 100);
     pub_global_odometry = n->create_publisher<nav_msgs::msg::Odometry>("global_odometry", 100);

--- a/loop_fusion/src/parameters.h
+++ b/loop_fusion/src/parameters.h
@@ -34,5 +34,6 @@ extern int ROW;
 extern int COL;
 extern std::string VINS_RESULT_PATH;
 extern int DEBUG_IMAGE;
-
-
+extern std::string WORLD_FRAME_ID;
+extern std::string BODY_FRAME_ID;
+extern std::string CAMERA_FRAME_ID;

--- a/loop_fusion/src/pose_graph.cpp
+++ b/loop_fusion/src/pose_graph.cpp
@@ -173,7 +173,7 @@ void PoseGraph::addKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
     pose_stamped.header.stamp.sec = sec_ts;
     pose_stamped.header.stamp.nanosec = nsec_ts;
 
-    pose_stamped.header.frame_id = "world";
+    pose_stamped.header.frame_id = WORLD_FRAME_ID;
     pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
     pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;
     pose_stamped.pose.position.z = P.z();
@@ -282,7 +282,7 @@ void PoseGraph::loadKeyFrame(KeyFrame* cur_kf, bool flag_detect_loop)
     pose_stamped.header.stamp.sec = sec_ts;
     pose_stamped.header.stamp.nanosec = nsec_ts;
 
-    pose_stamped.header.frame_id = "world";
+    pose_stamped.header.frame_id = WORLD_FRAME_ID;
     pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
     pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;
     pose_stamped.pose.position.z = P.z();
@@ -822,7 +822,7 @@ void PoseGraph::updatePath()
         pose_stamped.header.stamp.sec = sec_ts;
         pose_stamped.header.stamp.nanosec = nsec_ts;
 
-        pose_stamped.header.frame_id = "world";
+        pose_stamped.header.frame_id = WORLD_FRAME_ID;
         pose_stamped.pose.position.x = P.x() + VISUALIZATION_SHIFT_X;
         pose_stamped.pose.position.y = P.y() + VISUALIZATION_SHIFT_Y;
         pose_stamped.pose.position.z = P.z();

--- a/loop_fusion/src/pose_graph_node.cpp
+++ b/loop_fusion/src/pose_graph_node.cpp
@@ -61,6 +61,10 @@ int ROW;
 int COL;
 int DEBUG_IMAGE;
 
+std::string WORLD_FRAME_ID = "world";
+std::string BODY_FRAME_ID = "body";
+std::string CAMERA_FRAME_ID = "camera";
+
 camodocal::CameraPtr m_camera;
 Eigen::Vector3d tic;
 Eigen::Matrix3d qic;

--- a/loop_fusion/src/pose_graph_node.cpp
+++ b/loop_fusion/src/pose_graph_node.cpp
@@ -212,7 +212,7 @@ void vio_callback(const nav_msgs::msg::Odometry::SharedPtr pose_msg)
 
     nav_msgs::msg::Odometry odometry;
     odometry.header = pose_msg->header;
-    odometry.header.frame_id = "world";
+    odometry.header.frame_id = WORLD_FRAME_ID;
     odometry.pose.pose.position.x = vio_t.x();
     odometry.pose.pose.position.y = vio_t.y();
     odometry.pose.pose.position.z = vio_t.z();
@@ -466,6 +466,13 @@ int main(int argc, char **argv)
     fsSettings["pose_graph_save_path"] >> POSE_GRAPH_SAVE_PATH;
     fsSettings["output_path"] >> VINS_RESULT_PATH;
     fsSettings["save_image"] >> DEBUG_IMAGE;
+
+    fsSettings["world_frame_id"] >> WORLD_FRAME_ID;
+    WORLD_FRAME_ID.empty()? WORLD_FRAME_ID = "world" : WORLD_FRAME_ID;
+    fsSettings["body_frame_id"] >> BODY_FRAME_ID;   
+    BODY_FRAME_ID.empty()? BODY_FRAME_ID = "body" : BODY_FRAME_ID;
+    fsSettings["camera_frame_id"] >> CAMERA_FRAME_ID;
+    CAMERA_FRAME_ID.empty()? CAMERA_FRAME_ID = "camera" : CAMERA_FRAME_ID;
 
     LOAD_PREVIOUS_POSE_GRAPH = fsSettings["load_previous_pose_graph"];
     VINS_RESULT_PATH = VINS_RESULT_PATH + "/vio_loop.csv";

--- a/loop_fusion/src/utility/utility.h
+++ b/loop_fusion/src/utility/utility.h
@@ -145,5 +145,5 @@ class Utility
       else
         return angle_degrees +
             two_pi * std::floor((-angle_degrees + T(180)) / two_pi);
-    };
+    }
 };

--- a/vins/src/estimator/estimator.cpp
+++ b/vins/src/estimator/estimator.cpp
@@ -348,7 +348,7 @@ void Estimator::processMeasurements()
             printStatistics(*this, 0);
 
             std_msgs::msg::Header header;
-            header.frame_id = "world";
+            header.frame_id = WORLD_FRAME_ID;
 
             int sec_ts = (int)feature.first;
             uint nsec_ts = (uint)((feature.first - sec_ts) * 1e9);

--- a/vins/src/estimator/parameters.cpp
+++ b/vins/src/estimator/parameters.cpp
@@ -50,6 +50,9 @@ double F_THRESHOLD;
 int SHOW_TRACK;
 int FLOW_BACK;
 
+std::string WORLD_FRAME_ID;
+std::string BODY_FRAME_ID;
+std::string CAMERA_FRAME_ID;
 
 template <typename T>
 T readParam(rclcpp::Node::SharedPtr n, std::string name)
@@ -204,6 +207,16 @@ void readParameters(std::string config_file)
         ESTIMATE_TD = 0;
         printf("no imu, fix extrinsic param; no time offset calibration\n");
     }
+
+    fsSettings["global_frame_id"] >> WORLD_FRAME_ID;
+    WORLD_FRAME_ID.empty()? WORLD_FRAME_ID = "world" : WORLD_FRAME_ID;
+    fsSettings["body_frame_id"] >> BODY_FRAME_ID;   
+    BODY_FRAME_ID.empty()? BODY_FRAME_ID = "body" : BODY_FRAME_ID;
+    fsSettings["camera_frame_id"] >> CAMERA_FRAME_ID;
+    CAMERA_FRAME_ID.empty()? CAMERA_FRAME_ID = "camera" : CAMERA_FRAME_ID;
+    
+    ROS_INFO("frame_ids: world=%s body=%s camera=%s", WORLD_FRAME_ID.c_str(),
+             BODY_FRAME_ID.c_str(), CAMERA_FRAME_ID.c_str());
 
     fsSettings.release();
 }

--- a/vins/src/estimator/parameters.cpp
+++ b/vins/src/estimator/parameters.cpp
@@ -208,7 +208,7 @@ void readParameters(std::string config_file)
         printf("no imu, fix extrinsic param; no time offset calibration\n");
     }
 
-    fsSettings["global_frame_id"] >> WORLD_FRAME_ID;
+    fsSettings["world_frame_id"] >> WORLD_FRAME_ID;
     WORLD_FRAME_ID.empty()? WORLD_FRAME_ID = "world" : WORLD_FRAME_ID;
     fsSettings["body_frame_id"] >> BODY_FRAME_ID;   
     BODY_FRAME_ID.empty()? BODY_FRAME_ID = "body" : BODY_FRAME_ID;

--- a/vins/src/estimator/parameters.h
+++ b/vins/src/estimator/parameters.h
@@ -71,6 +71,9 @@ extern int MIN_DIST;
 extern double F_THRESHOLD;
 extern int SHOW_TRACK;
 extern int FLOW_BACK;
+extern std::string WORLD_FRAME_ID;
+extern std::string BODY_FRAME_ID;
+extern std::string CAMERA_FRAME_ID;
 
 void readParameters(std::string config_file);
 

--- a/vins/src/utility/utility.h
+++ b/vins/src/utility/utility.h
@@ -145,5 +145,5 @@ class Utility
       else
         return angle_degrees +
             two_pi * std::floor((-angle_degrees + T(180)) / two_pi);
-    };
+    }
 };

--- a/vins/src/utility/visualization.cpp
+++ b/vins/src/utility/visualization.cpp
@@ -59,7 +59,7 @@ void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, co
     odometry.header.stamp.sec = sec_ts;
     odometry.header.stamp.nanosec = nsec_ts;
 
-    odometry.header.frame_id = "world";
+    odometry.header.frame_id = WORLD_FRAME_ID;
     odometry.pose.pose.position.x = P.x();
     odometry.pose.pose.position.y = P.y();
     odometry.pose.pose.position.z = P.z();
@@ -76,7 +76,7 @@ void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, co
 void pubTrackImage(const cv::Mat &imgTrack, const double t)
 {
     std_msgs::msg::Header header;
-    header.frame_id = "world";
+    header.frame_id = WORLD_FRAME_ID;
 
     int sec_ts = (int)t;
     uint nsec_ts = (uint)((t - sec_ts) * 1e9);
@@ -138,8 +138,8 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
     {
         nav_msgs::msg::Odometry odometry;
         odometry.header = header;
-        odometry.header.frame_id = "world";
-        odometry.child_frame_id = "world";
+        odometry.header.frame_id = WORLD_FRAME_ID;
+        odometry.child_frame_id = BODY_FRAME_ID;
         Quaterniond tmp_Q;
         tmp_Q = Quaterniond(estimator.Rs[WINDOW_SIZE]);
         odometry.pose.pose.position.x = estimator.Ps[WINDOW_SIZE].x();
@@ -156,10 +156,10 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
 
         geometry_msgs::msg::PoseStamped pose_stamped;
         pose_stamped.header = header;
-        pose_stamped.header.frame_id = "world";
+        pose_stamped.header.frame_id = WORLD_FRAME_ID;
         pose_stamped.pose = odometry.pose.pose;
         path.header = header;
-        path.header.frame_id = "world";
+        path.header.frame_id = WORLD_FRAME_ID;
         path.poses.push_back(pose_stamped);
         pub_path->publish(path);
 
@@ -193,7 +193,7 @@ void pubKeyPoses(const Estimator &estimator, const std_msgs::msg::Header &header
         return;
     visualization_msgs::msg::Marker key_poses;
     key_poses.header = header;
-    key_poses.header.frame_id = "world";
+    key_poses.header.frame_id = WORLD_FRAME_ID;
     key_poses.ns = "key_poses";
     key_poses.type = visualization_msgs::msg::Marker::SPHERE_LIST;
     key_poses.action = visualization_msgs::msg::Marker::ADD;
@@ -233,7 +233,7 @@ void pubCameraPose(const Estimator &estimator, const std_msgs::msg::Header &head
 
         nav_msgs::msg::Odometry odometry;
         odometry.header = header;
-        odometry.header.frame_id = "world";
+        odometry.header.frame_id = WORLD_FRAME_ID;
         odometry.pose.pose.position.x = P.x();
         odometry.pose.pose.position.y = P.y();
         odometry.pose.pose.position.z = P.z();
@@ -347,8 +347,8 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
 
 
     // transform.header.stamp = header.stamp;
-    transform.header.frame_id = "world";
-    transform.child_frame_id = "body";
+    transform.header.frame_id = WORLD_FRAME_ID;
+    transform.child_frame_id = BODY_FRAME_ID;
 
     transform.transform.translation.x = correct_t(0);
     transform.transform.translation.y = correct_t(1);
@@ -377,8 +377,8 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
 
     // camera frame
     transform_cam.header.stamp = header.stamp;
-    transform_cam.header.frame_id = "body";
-    transform_cam.child_frame_id = "camera";
+    transform_cam.header.frame_id = BODY_FRAME_ID;
+    transform_cam.child_frame_id = CAMERA_FRAME_ID;
 
 
     transform_cam.transform.translation.x = estimator.tic[0].x();
@@ -402,7 +402,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
     
     nav_msgs::msg::Odometry odometry;
     odometry.header = header;
-    odometry.header.frame_id = "world";
+    odometry.header.frame_id = WORLD_FRAME_ID;
     odometry.pose.pose.position.x = estimator.tic[0].x();
     odometry.pose.pose.position.y = estimator.tic[0].y();
     odometry.pose.pose.position.z = estimator.tic[0].z();
@@ -458,7 +458,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
     
 //     nav_msgs::msg::Odometry odometry;
 //     odometry.header = header;
-//     odometry.header.frame_id = "world";
+//     odometry.header.frame_id = WORLD_FRAME_ID;
 //     odometry.pose.pose.position.x = estimator.tic[0].x();
 //     odometry.pose.pose.position.y = estimator.tic[0].y();
 //     odometry.pose.pose.position.z = estimator.tic[0].z();
@@ -488,7 +488,7 @@ void pubKeyframe(const Estimator &estimator)
         odometry.header.stamp.sec = sec_ts;
         odometry.header.stamp.nanosec = nsec_ts;
 
-        odometry.header.frame_id = "world";
+        odometry.header.frame_id = WORLD_FRAME_ID;
         odometry.pose.pose.position.x = P.x();
         odometry.pose.pose.position.y = P.y();
         odometry.pose.pose.position.z = P.z();
@@ -508,7 +508,7 @@ void pubKeyframe(const Estimator &estimator)
         point_cloud.header.stamp.sec = sec_ts;
         point_cloud.header.stamp.nanosec = nsec_ts;
 
-        point_cloud.header.frame_id = "world";
+        point_cloud.header.frame_id = WORLD_FRAME_ID;
         for (auto &it_per_id : estimator.f_manager.feature)
         {
             int frame_size = it_per_id.feature_per_frame.size();


### PR DESCRIPTION
QoL:
- Changed hardcoded frame_ids to parameters:
`WORLD_FRAME_ID` `BODY_FRAME_ID` `CAMERA_FRAME_ID`
with default values `world`, `body`, `camera` respectively to be backward compatible.
- These frame ids are modifiable in the config file by using 
```
 world_frame_id: world
 body_frame_id: body
 camera_frame_id: camera
```
- For the global fusion node `world_frame_id` and `body_frame_id` can be passed as ros arguments.
 
Fix:
- Published Odometry sets parent frame id and child frame id to world. Odometry should describe a child object (i.e. the body frame) behavior in the world it lives in (i.e. world frame). 

Tested on ROS2 Humble